### PR TITLE
Periodically storing state chain 

### DIFF
--- a/iron-indexer.toml
+++ b/iron-indexer.toml
@@ -1,5 +1,7 @@
 [reth]
 db = "/mnt/data/eth/sepolia/reth/db"
+
+[chain]
 chain_id = 11155111
 start_block = 4794550
 

--- a/migrations/2023-11-28-190011_create_txs/down.sql
+++ b/migrations/2023-11-28-190011_create_txs/down.sql
@@ -1,1 +1,1 @@
--- This file should undo anything in `up.sql`
+DROP TABLE txs;

--- a/migrations/2023-11-30-220900_chains/down.sql
+++ b/migrations/2023-11-30-220900_chains/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE chains;

--- a/migrations/2023-11-30-220900_chains/up.sql
+++ b/migrations/2023-11-30-220900_chains/up.sql
@@ -1,0 +1,7 @@
+CREATE TABLE chains (
+  chain_id INTEGER NOT NULL,
+  start_block INTEGER NOT NULL,
+  last_known_block INTEGER NOT NULL,
+  updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (chain_id)
+);

--- a/src/config.rs
+++ b/src/config.rs
@@ -14,6 +14,7 @@ struct Args {
 #[derive(Deserialize, Clone, Debug)]
 pub struct Config {
     pub reth: RethConfig,
+    pub chain: ChainConfig,
     pub sync: SyncConfig,
 
     #[serde(default)]
@@ -25,8 +26,11 @@ pub struct Config {
 #[derive(Deserialize, Clone, Debug)]
 pub struct RethConfig {
     pub db: PathBuf,
-    pub chain_id: u64,
+}
 
+#[derive(Debug, Clone, Deserialize)]
+pub struct ChainConfig {
+    pub chain_id: u64,
     #[serde(default = "default_from_block")]
     pub start_block: u64,
 }

--- a/src/db/models.rs
+++ b/src/db/models.rs
@@ -2,10 +2,10 @@ use diesel::pg::Pg;
 use diesel::prelude::*;
 use serde::{Deserialize, Serialize};
 
-use super::schema::{accounts, txs};
+use super::schema::{accounts, chains, txs};
 use super::types::{Address, B256};
 
-#[derive(Queryable, Selectable, Serialize)]
+#[derive(Debug, Queryable, Selectable, Serialize)]
 #[diesel(table_name = accounts, check_for_backend(Pg))]
 pub struct Account {
     pub address: Address,
@@ -21,7 +21,7 @@ pub struct Register {
     pub chain_id: i32,
 }
 
-#[derive(Queryable, Selectable, Serialize)]
+#[derive(Debug, Queryable, Selectable, Serialize)]
 #[diesel(table_name = txs, check_for_backend(Pg))]
 pub struct Txs {
     pub address: Address,
@@ -39,4 +39,13 @@ pub struct CreateTx {
     pub chain_id: i32,
     pub hash: B256,
     pub block_number: i32,
+}
+
+#[derive(Debug, Queryable, Selectable)]
+#[diesel(table_name = chains, check_for_backend(Pg))]
+pub struct Chain {
+    pub chain_id: i32,
+    pub start_block: i32,
+    pub last_known_block: i32,
+    pub updated_at: chrono::NaiveDateTime,
 }

--- a/src/db/schema.rs
+++ b/src/db/schema.rs
@@ -10,6 +10,15 @@ diesel::table! {
 }
 
 diesel::table! {
+    chains (chain_id) {
+        chain_id -> Int4,
+        start_block -> Int4,
+        last_known_block -> Int4,
+        updated_at -> Timestamp,
+    }
+}
+
+diesel::table! {
     txs (address, chain_id, hash) {
         address -> Bytea,
         chain_id -> Int4,
@@ -22,5 +31,6 @@ diesel::table! {
 
 diesel::allow_tables_to_appear_in_same_query!(
     accounts,
+    chains,
     txs,
 );


### PR DESCRIPTION
As we sync, state is updated in the following way:
- in the initial catch-up, a buffer of ~1000 items is kept. once the buffer reaches capacity, we flush to the database
- after that initial point, since we have time in between waiting for blocks, we flush each individual block
- whenever we flush, we also update the chain info to the latest known tip, which will ensure we keep sync status across restarts
- all db updates ignore conflicts, so that we're resilient against attempting to include the same item twice (shouldn't happen with the current logic, but we can never be too careful)

but actually this PR is mainly concerned with setting up chain info on the database, and keeping it up-to-date