### PR TITLE
Creating backfill job records for new registrations

### DIFF
--- a/migrations/2023-12-01-114852_create_backfill_jobs/down.sql
+++ b/migrations/2023-12-01-114852_create_backfill_jobs/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE jobs;

--- a/migrations/2023-12-01-114852_create_backfill_jobs/up.sql
+++ b/migrations/2023-12-01-114852_create_backfill_jobs/up.sql
@@ -1,0 +1,11 @@
+CREATE TABLE backfill_jobs (
+  id SERIAL,
+  address BYTEA NOT NULL,
+  chain_id INTEGER NOT NULL,
+  from_block INTEGER NOT NULL,
+  to_block INTEGER NOT NULL,
+  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (id),
+  FOREIGN KEY (address, chain_id) REFERENCES accounts (address, chain_id)
+);

--- a/src/api/routes.rs
+++ b/src/api/routes.rs
@@ -1,19 +1,25 @@
 use super::error::Result;
-use crate::db::{models::Register, Db};
+use crate::db::Db;
 use actix_web::{
     get, post,
     web::{self, Json},
     HttpResponse, Responder,
 };
+use serde::Deserialize;
 
 #[get("/health")]
 async fn health() -> impl Responder {
     HttpResponse::Ok()
 }
 
+#[derive(Debug, Deserialize)]
+struct Register {
+    address: alloy_primitives::Address,
+}
+
 #[post("/register")]
 async fn register(db: web::Data<Db>, Json(register): Json<Register>) -> Result<impl Responder> {
-    db.register(register).await?;
+    db.register(register.address.into()).await?;
 
     Ok(HttpResponse::Ok())
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -30,7 +30,7 @@ pub struct RethConfig {
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct ChainConfig {
-    pub chain_id: u64,
+    pub chain_id: i32,
     #[serde(default = "default_from_block")]
     pub start_block: u64,
 }

--- a/src/db/models.rs
+++ b/src/db/models.rs
@@ -2,7 +2,7 @@ use diesel::pg::Pg;
 use diesel::prelude::*;
 use serde::{Deserialize, Serialize};
 
-use super::schema::{accounts, chains, txs};
+use super::schema::{accounts, backfill_jobs, chains, txs};
 use super::types::{Address, B256};
 
 #[derive(Debug, Queryable, Selectable, Serialize)]
@@ -12,13 +12,6 @@ pub struct Account {
     pub chain_id: i32,
     pub created_at: chrono::NaiveDateTime,
     pub updated_at: chrono::NaiveDateTime,
-}
-
-#[derive(Debug, Deserialize, Insertable)]
-#[diesel(table_name = accounts, check_for_backend(Pg))]
-pub struct Register {
-    pub address: Address,
-    pub chain_id: i32,
 }
 
 #[derive(Debug, Queryable, Selectable, Serialize)]
@@ -47,5 +40,16 @@ pub struct Chain {
     pub chain_id: i32,
     pub start_block: i32,
     pub last_known_block: i32,
+    pub updated_at: chrono::NaiveDateTime,
+}
+
+#[derive(Debug, Queryable, Selectable)]
+#[diesel(table_name = backfill_jobs, check_for_backend(Pg))]
+pub struct BackfillJob {
+    pub address: Address,
+    pub chain_id: i32,
+    pub from_block: i32,
+    pub to_block: i32,
+    pub created_at: chrono::NaiveDateTime,
     pub updated_at: chrono::NaiveDateTime,
 }

--- a/src/db/schema.rs
+++ b/src/db/schema.rs
@@ -10,6 +10,18 @@ diesel::table! {
 }
 
 diesel::table! {
+    backfill_jobs (id) {
+        id -> Int4,
+        address -> Bytea,
+        chain_id -> Int4,
+        from_block -> Int4,
+        to_block -> Int4,
+        created_at -> Timestamp,
+        updated_at -> Timestamp,
+    }
+}
+
+diesel::table! {
     chains (chain_id) {
         chain_id -> Int4,
         start_block -> Int4,
@@ -31,6 +43,7 @@ diesel::table! {
 
 diesel::allow_tables_to_appear_in_same_query!(
     accounts,
+    backfill_jobs,
     chains,
     txs,
 );

--- a/src/events.rs
+++ b/src/events.rs
@@ -1,0 +1,6 @@
+use alloy_primitives::Address;
+
+#[derive(Debug, Clone)]
+pub enum Event {
+    AccountRegistered { address: Address },
+}


### PR DESCRIPTION
When a new address is registered (currently through the HTTP API), we start monitoring immediately in the main sync job, but we also need to eventually backfill his data for past blocks

Here, we create a backfill record, which will eventually be picked up by a worker pool (for a later PR)