### PR TITLE
Jobs array

### DIFF
--- a/diesel.patch
+++ b/diesel.patch
@@ -1,13 +1,14 @@
 diff --git a/src/db/schema.rs b/src/db/schema.rs
-index c147275..8bb6b9d 100644
+index d105e29..7773c57 100644
 --- a/src/db/schema.rs
 +++ b/src/db/schema.rs
-@@ -4,7 +4,7 @@ diesel::table! {
-     accounts (id) {
-         id -> Int4,
-         address -> Bytea,
--        chain_ids -> Array<Nullable<Int4>>,
-+        chain_ids -> Array<Int4>,
-         created_at -> Timestamp,
-     }
- }
+@@ -11,7 +11,7 @@ diesel::table! {
+ 
+ diesel::table! {
+     backfill_jobs (chain_id, from_block, to_block) {
+-        address -> Array<Nullable<Bytea>>,
++        address -> Array<Bytea>,
+         chain_id -> Int4,
+         from_block -> Int4,
+         to_block -> Int4,
+@@ -42,9 +42,4 @@ diesel::table! {

--- a/diesel.patch
+++ b/diesel.patch
@@ -6,9 +6,8 @@ index d105e29..7773c57 100644
  
  diesel::table! {
      backfill_jobs (chain_id, from_block, to_block) {
--        address -> Array<Nullable<Bytea>>,
-+        address -> Array<Bytea>,
+-        addresses -> Array<Nullable<Bytea>>,
++        addresses -> Array<Bytea>,
          chain_id -> Int4,
          from_block -> Int4,
          to_block -> Int4,
-@@ -42,9 +42,4 @@ diesel::table! {

--- a/diesel.toml
+++ b/diesel.toml
@@ -4,7 +4,7 @@
 [print_schema]
 file = "src/db/schema.rs"
 custom_type_derives = ["diesel::query_builder::QueryId"]
-# patch_file = "diesel.patch"
+patch_file = "diesel.patch"
 
 [migrations_directory]
 dir = "migrations"

--- a/diesel.toml
+++ b/diesel.toml
@@ -4,6 +4,7 @@
 [print_schema]
 file = "src/db/schema.rs"
 custom_type_derives = ["diesel::query_builder::QueryId"]
+# patch_file = "diesel.patch"
 
 [migrations_directory]
 dir = "migrations"

--- a/migrations/2023-12-01-114852_create_backfill_jobs/up.sql
+++ b/migrations/2023-12-01-114852_create_backfill_jobs/up.sql
@@ -1,5 +1,5 @@
 CREATE TABLE backfill_jobs (
-  address BYTEA[] NOT NULL,
+  addresses BYTEA[] NOT NULL,
   chain_id INTEGER NOT NULL,
   from_block INTEGER NOT NULL,
   to_block INTEGER NOT NULL,

--- a/migrations/2023-12-01-114852_create_backfill_jobs/up.sql
+++ b/migrations/2023-12-01-114852_create_backfill_jobs/up.sql
@@ -1,11 +1,10 @@
 CREATE TABLE backfill_jobs (
-  id SERIAL,
-  address BYTEA NOT NULL,
+  address BYTEA[] NOT NULL,
   chain_id INTEGER NOT NULL,
   from_block INTEGER NOT NULL,
   to_block INTEGER NOT NULL,
   created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
   updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  PRIMARY KEY (id),
-  FOREIGN KEY (chain_id, address) REFERENCES accounts (chain_id, address)
+  PRIMARY KEY (chain_id, from_block, to_block),
+  FOREIGN KEY (chain_id) REFERENCES chains (chain_id)
 );

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -134,7 +134,7 @@ impl Db {
 
         let res = insert_into(dsl::backfill_jobs)
             .values((
-                dsl::address.eq(address),
+                dsl::addresses.eq(vec![address]),
                 dsl::chain_id.eq(chain_id),
                 dsl::from_block.eq(from_block),
                 dsl::to_block.eq(to_block),

--- a/src/db/models.rs
+++ b/src/db/models.rs
@@ -46,7 +46,7 @@ pub struct Chain {
 #[derive(Debug, Queryable, Selectable, Insertable)]
 #[diesel(table_name = backfill_jobs, check_for_backend(Pg))]
 pub struct BackfillJob {
-    pub address: Address,
+    pub addresses: Vec<Address>,
     pub chain_id: i32,
     pub from_block: i32,
     pub to_block: i32,

--- a/src/db/schema.rs
+++ b/src/db/schema.rs
@@ -10,9 +10,8 @@ diesel::table! {
 }
 
 diesel::table! {
-    backfill_jobs (id) {
-        id -> Int4,
-        address -> Bytea,
+    backfill_jobs (chain_id, from_block, to_block) {
+        address -> Array<Nullable<Bytea>>,
         chain_id -> Int4,
         from_block -> Int4,
         to_block -> Int4,
@@ -40,6 +39,8 @@ diesel::table! {
         updated_at -> Timestamp,
     }
 }
+
+diesel::joinable!(backfill_jobs -> chains (chain_id));
 
 diesel::allow_tables_to_appear_in_same_query!(
     accounts,

--- a/src/db/schema.rs
+++ b/src/db/schema.rs
@@ -11,7 +11,7 @@ diesel::table! {
 
 diesel::table! {
     backfill_jobs (chain_id, from_block, to_block) {
-        address -> Array<Nullable<Bytea>>,
+        addresses -> Array<Bytea>,
         chain_id -> Int4,
         from_block -> Int4,
         to_block -> Int4,

--- a/src/db/types.rs
+++ b/src/db/types.rs
@@ -11,7 +11,7 @@ use diesel::{
 };
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Deserialize, Serialize, AsExpression, FromSqlRow)]
+#[derive(Debug, Deserialize, Serialize, AsExpression, FromSqlRow, Clone)]
 #[diesel(sql_type=Bytea)]
 pub struct Address(pub alloy_primitives::Address);
 


### PR DESCRIPTION
Each job entry now holds an array of addresses, which saves a lot of space, and work when updating a job's status